### PR TITLE
Split up the workload of generating ngram files to save RAM

### DIFF
--- a/ntrans_dataprep.py
+++ b/ntrans_dataprep.py
@@ -117,8 +117,6 @@ def generate_ngrams_from_corpus():
         if count % 10000 == 0:
             print(count)
 
-        # Splits up the proecssing of sentences into chunks of 300K, and clears the dict where
-        # the data is temporarily stored.
         if count != 0 and count % 300000 == 0:
             count_ngram_frequency(n_to_ngrams, data_chunk)
             data_chunk += 1

--- a/ntrans_dataprep.py
+++ b/ntrans_dataprep.py
@@ -7,10 +7,10 @@ http://www.ota.ox.ac.uk/desc/2554
 
 Unzip BNC to the working directory, and rename the folder `BNC`.
 
-NOTE: The BNC contains around 112.000.000 words (or 6.020.000+ sentences).
+NOTE: The BNC contains around 112M words (or 6M+ sentences).
 It can take around 1,5 hours to run this script.
 
-The script generates 236.937.946 N-grams.
+The script generates 237M N-grams.
 
 """
 
@@ -22,7 +22,7 @@ import pathlib
 from datetime import datetime
 
 
-def write_data_to_csv(n_to_ngrams, data_chunk):
+def write_data_to_csv(n_to_ngrams, chunk_number):
     """
     Writes the N-grams to CSV files in chunks of 300K sentences.
 
@@ -35,13 +35,13 @@ def write_data_to_csv(n_to_ngrams, data_chunk):
 
     print(
         "Writing data chunk #"
-        + str(data_chunk)
+        + str(chunk_number)
         + " to csv – Current time: "
         + current_time
     )
 
     for n, collections_counter in n_to_ngrams.items():
-        file_path = f"./ngrams/chunk{data_chunk}_{n}-grams.csv"
+        file_path = f"./ngrams/chunk{chunk_number}_{n}-grams.csv"
 
         with open(file_path, mode="w") as write_data_file:
             data_writer = csv.writer(write_data_file)
@@ -51,7 +51,7 @@ def write_data_to_csv(n_to_ngrams, data_chunk):
                 data_writer.writerow(csv_row)
 
 
-def count_ngram_frequency(n_to_ngrams, data_chunk):
+def count_ngram_frequency(n_to_ngrams, chunk_number):
     """
     Counts the frequency of each N-gram to distinguish the most common ones.
     """
@@ -59,7 +59,7 @@ def count_ngram_frequency(n_to_ngrams, data_chunk):
     # Example output: "2: Counter({('of', 'the'): 64, ('in', 'the'): 48, ('gift', 'aid'): 27..."
     write_data_to_csv(
         {n: collections.Counter(ngrams) for n, ngrams in n_to_ngrams.items()},
-        data_chunk,
+        chunk_number,
     )
 
 
@@ -107,9 +107,7 @@ def generate_ngrams_from_corpus():
         root="BNC/Texts/", fileids=r"[A-K]/\w*/\w*\.xml"
     )
 
-    # Tells the program how to name the generated csv-files when splitting data into several
-    # files.
-    data_chunk = 1
+    chunk_number = 1
 
     # To work with a sample size of the BNC, add a range in sents().
     # For example "for count, sentence in enumerate(bnc_corpus.sents()[:1000]):"
@@ -120,9 +118,10 @@ def generate_ngrams_from_corpus():
         # Splits up the proecssing of sentences into chunks of 300K, and clears the dict where
         # the data is temporarily stored.
         if count != 0 and count % 300000 == 0:
-            count_ngram_frequency(n_to_ngrams, data_chunk)
-            data_chunk += 1
+            count_ngram_frequency(n_to_ngrams, chunk_number)
+            chunk_number += 1
 
+            # Avoids filling up RAM
             for n in n_to_ngrams:
                 n_to_ngrams[n].clear()
 
@@ -140,7 +139,7 @@ def generate_ngrams_from_corpus():
             if sentence_length >= n:
                 n_to_ngrams[n].extend(nltk.ngrams(processed_sentence, n))
 
-    count_ngram_frequency(n_to_ngrams, data_chunk)
+    count_ngram_frequency(n_to_ngrams, chunk_number)
 
 
 generate_ngrams_from_corpus()

--- a/ntrans_dataprep.py
+++ b/ntrans_dataprep.py
@@ -51,16 +51,13 @@ def write_data_to_csv(n_to_ngrams, chunk_number):
                 data_writer.writerow(csv_row)
 
 
-def count_ngram_frequency(n_to_ngrams, chunk_number):
+def count_ngram_frequency(n_to_ngrams):
     """
     Counts the frequency of each N-gram to distinguish the most common ones.
     """
 
     # Example output: "2: Counter({('of', 'the'): 64, ('in', 'the'): 48, ('gift', 'aid'): 27..."
-    write_data_to_csv(
-        {n: collections.Counter(ngrams) for n, ngrams in n_to_ngrams.items()},
-        chunk_number,
-    )
+    return {n: collections.Counter(ngrams) for n, ngrams in n_to_ngrams.items()}
 
 
 def format_corpus_sents(sentence):
@@ -137,7 +134,7 @@ def generate_ngrams_from_corpus():
             if sentence_length >= n:
                 n_to_ngrams[n].extend(nltk.ngrams(processed_sentence, n))
 
-    count_ngram_frequency(n_to_ngrams, chunk_number)
+    write_data_to_csv(count_ngram_frequency(n_to_ngrams), chunk_number)
 
 
 generate_ngrams_from_corpus()

--- a/ntrans_dataprep.py
+++ b/ntrans_dataprep.py
@@ -31,9 +31,14 @@ def write_data_to_csv(n_to_ngrams, data_chunk):
     pathlib.Path("ngrams").mkdir(exist_ok=True)
 
     now = datetime.now()
-    current_time = now.strftime('%H:%M:%S')
+    current_time = now.strftime("%H:%M:%S")
 
-    print("Writing data chunk #" + str(data_chunk) + " to csv – Current time: " + current_time)
+    print(
+        "Writing data chunk #"
+        + str(data_chunk)
+        + " to csv – Current time: "
+        + current_time
+    )
 
     for n, collections_counter in n_to_ngrams.items():
         file_path = f"./ngrams/chunk{data_chunk}_{n}-grams.csv"
@@ -53,7 +58,8 @@ def count_ngram_frequency(n_to_ngrams, data_chunk):
 
     # Example output: "2: Counter({('of', 'the'): 64, ('in', 'the'): 48, ('gift', 'aid'): 27..."
     write_data_to_csv(
-        {n: collections.Counter(ngrams) for n, ngrams in n_to_ngrams.items()}, data_chunk
+        {n: collections.Counter(ngrams) for n, ngrams in n_to_ngrams.items()},
+        data_chunk,
     )
 
 


### PR DESCRIPTION
It currently takes 5 minutes & 45 seconds on my system to process the first 500K sentences and create a "chunk 1"-file for each N-gram.

This would create around 10 files for each N-gram. This used around 2GB of Swap.

Processing 500K sentences by generating files for every 100K sentences took the same amount of time, but used much less RAM. However, this would create many more chunk-files.

After processing 500K sentenes into 6 files (1 chunk for each N-gram), the folder with N-gram files is 640 MB. This means that the full data set would be around 6GB. I am afraid this is way too much.

I have to consider limiting the data included in the program.

I might generate the data, and then write the 5 or 10.000 most common for each N-gram to the files which are included in the end program.

@Akuli Do you have any ideas?

![Screenshot 2021-05-22 at 00 51 53](https://user-images.githubusercontent.com/76887896/119205648-1630ed80-ba99-11eb-9f4f-e0e17a9bbf0f.png)

![Screenshot 2021-05-22 at 00 52 15](https://user-images.githubusercontent.com/76887896/119205658-1e892880-ba99-11eb-85fa-efdefb460677.png)

